### PR TITLE
Fix exec-command output

### DIFF
--- a/.github/workflows/on-push-verification.yml
+++ b/.github/workflows/on-push-verification.yml
@@ -29,7 +29,7 @@ jobs:
     #   id: msdo
 
       # Run analyzers
-    - uses: ContosoDfDEnterprise/larohra-security-devops-action@fix-api-call
+    - uses: ContosoDfDEnterprise/larohra-security-devops-action@larohra/fix-api-call
       id: msdo
       with:
         features: mapping

--- a/.github/workflows/on-push-verification.yml
+++ b/.github/workflows/on-push-verification.yml
@@ -29,20 +29,20 @@ jobs:
     #   id: msdo
 
       # Run analyzers
-    - uses: ContosoDfDEnterprise/larohra-security-devops-action@larohra/fix-api-call
+    - uses: microsoft/security-devops-action@containerMappingPreview
       id: msdo
       with:
         features: mapping
 
       # Upload alerts to the Security tab
-    # - name: Upload alerts to Security tab
-    #   uses: github/codeql-action/upload-sarif@v2
-    #   with:
-    #     sarif_file: ${{ steps.msdo.outputs.sarifFile }}
+    - name: Upload alerts to Security tab
+      uses: github/codeql-action/upload-sarif@v2
+      with:
+        sarif_file: ${{ steps.msdo.outputs.sarifFile }}
 
-    #   # Upload alerts file as a workflow artifact
-    # - name: Upload alerts file as a workflow artifact
-    #   uses: actions/upload-artifact@v3
-    #   with:  
-    #     name: alerts
-    #     path: ${{ steps.msdo.outputs.sarifFile }}
+      # Upload alerts file as a workflow artifact
+    - name: Upload alerts file as a workflow artifact
+      uses: actions/upload-artifact@v3
+      with:  
+        name: alerts
+        path: ${{ steps.msdo.outputs.sarifFile }}

--- a/.github/workflows/on-push-verification.yml
+++ b/.github/workflows/on-push-verification.yml
@@ -29,20 +29,20 @@ jobs:
     #   id: msdo
 
       # Run analyzers
-    - uses: microsoft/security-devops-action@containerMappingPreview
+    - uses: ContosoDfDEnterprise/larohra-security-devops-action@fix-api-call
       id: msdo
       with:
-        tools: container-mapping
+        features: mapping
 
       # Upload alerts to the Security tab
-    - name: Upload alerts to Security tab
-      uses: github/codeql-action/upload-sarif@v2
-      with:
-        sarif_file: ${{ steps.msdo.outputs.sarifFile }}
+    # - name: Upload alerts to Security tab
+    #   uses: github/codeql-action/upload-sarif@v2
+    #   with:
+    #     sarif_file: ${{ steps.msdo.outputs.sarifFile }}
 
-      # Upload alerts file as a workflow artifact
-    - name: Upload alerts file as a workflow artifact
-      uses: actions/upload-artifact@v3
-      with:  
-        name: alerts
-        path: ${{ steps.msdo.outputs.sarifFile }}
+    #   # Upload alerts file as a workflow artifact
+    # - name: Upload alerts file as a workflow artifact
+    #   uses: actions/upload-artifact@v3
+    #   with:  
+    #     name: alerts
+    #     path: ${{ steps.msdo.outputs.sarifFile }}

--- a/lib/container-mapping.js
+++ b/lib/container-mapping.js
@@ -67,14 +67,14 @@ class ContainerMapping {
     runPostJob() {
         return __awaiter(this, void 0, void 0, function* () {
             try {
-                (0, msdo_helpers_1.writeToOutStream)("::group::Microsoft Defender for DevOps container mapping post-job - https://go.microsoft.com/fwlink/?linkid=2231419");
+                core.info("::group::Microsoft Defender for DevOps container mapping post-job - https://go.microsoft.com/fwlink/?linkid=2231419");
                 yield this._runPostJob();
             }
             catch (error) {
-                (0, msdo_helpers_1.writeToOutStream)("Error in Container Mapping post-job: " + error);
+                core.info("Error in Container Mapping post-job: " + error);
             }
             finally {
-                (0, msdo_helpers_1.writeToOutStream)("::endgroup::");
+                core.info("::endgroup::");
             }
         });
     }
@@ -83,10 +83,9 @@ class ContainerMapping {
             let startTime = core.getState('PreJobStartTime');
             if (startTime.length <= 0) {
                 startTime = new Date(new Date().getTime() - 10000).toISOString();
-                console.log(`PreJobStartTime not defined, using now-10secs`);
+                core.debug(`PreJobStartTime not defined, using now-10secs`);
             }
-            console.log(`PreJobStartTime: ${startTime}`);
-            let dockerVersion = [];
+            core.info(`PreJobStartTime: ${startTime}`);
             let reportData = {
                 dockerVersion: "",
                 dockerEvents: [],
@@ -99,12 +98,6 @@ class ContainerMapping {
                 return;
             }
             reportData.dockerVersion = dockerVersionOutput.stdout.trim();
-            yield exec.getExecOutput('docker events --since ' + startTime + ' --until ' + new Date().toISOString() + ' --filter event=push --filter type=image --format ID={{.ID}}')
-                .then((result) => {
-                result.stdout.trim().split(os.EOL).forEach(element => {
-                    reportData.dockerEvents.push(element);
-                });
-            });
             yield this.execCommand(`docker events --since ${startTime} --until ${new Date().toISOString()} --filter event=push --filter type=image --format ID={{.ID}}`, reportData.dockerEvents)
                 .catch((error) => {
                 throw new Error("Unable to get docker events: " + error);
@@ -137,7 +130,9 @@ class ContainerMapping {
                     return Promise.reject(`Command execution failed: ${result}`);
                 }
                 result.stdout.trim().split(os.EOL).forEach(element => {
-                    listener.push(element);
+                    if (element.length > 0) {
+                        listener.push(element);
+                    }
                 });
             });
         });
@@ -154,7 +149,7 @@ class ContainerMapping {
                     return false;
                 }
                 else {
-                    (0, msdo_helpers_1.writeToOutStream)(`Retrying API call due to error: ${error}.\nRetry count: ${retryCount}`);
+                    core.info(`Retrying API call due to error: ${error}.\nRetry count: ${retryCount}`);
                     retryCount--;
                     return yield this.sendReport(data, bearerToken, retryCount);
                 }

--- a/lib/container-mapping.js
+++ b/lib/container-mapping.js
@@ -33,7 +33,6 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.ContainerMapping = void 0;
-const msdo_helpers_1 = require("./msdo-helpers");
 const https = __importStar(require("https"));
 const core = __importStar(require("@actions/core"));
 const exec = __importStar(require("@actions/exec"));
@@ -45,20 +44,20 @@ class ContainerMapping {
     }
     runPreJob() {
         try {
-            (0, msdo_helpers_1.writeToOutStream)("::group::Microsoft Defender for DevOps container mapping pre-job - https://go.microsoft.com/fwlink/?linkid=2231419");
+            core.info("::group::Microsoft Defender for DevOps container mapping pre-job - https://go.microsoft.com/fwlink/?linkid=2231419");
             this._runPreJob();
         }
         catch (error) {
-            (0, msdo_helpers_1.writeToOutStream)("Error in Container Mapping pre-job: " + error);
+            core.info("Error in Container Mapping pre-job: " + error);
         }
         finally {
-            (0, msdo_helpers_1.writeToOutStream)("::endgroup::");
+            core.info("::endgroup::");
         }
     }
     _runPreJob() {
         const startTime = new Date().toISOString();
         core.saveState('PreJobStartTime', startTime);
-        console.log('PreJobStartTime', startTime);
+        core.info(`PreJobStartTime: ${startTime}`);
     }
     runMain() {
         return __awaiter(this, void 0, void 0, function* () {
@@ -92,7 +91,7 @@ class ContainerMapping {
                 dockerImages: []
             };
             let dockerVersionOutput = yield exec.getExecOutput('docker --version');
-            if (dockerVersionOutput.exitCode != 0 || dockerVersionOutput.stderr.length > 0) {
+            if (dockerVersionOutput.exitCode != 0) {
                 core.info(`Unable to get docker version: ${dockerVersionOutput}`);
                 core.info(`Skipping container mapping since docker not found/available.`);
                 return;
@@ -120,6 +119,7 @@ class ContainerMapping {
                 throw new Error("Unable to send report to backend service");
             }
             ;
+            core.info("Container mapping data sent successfully.");
         });
     }
     execCommand(command, listener) {

--- a/lib/container-mapping.js
+++ b/lib/container-mapping.js
@@ -92,11 +92,19 @@ class ContainerMapping {
                 dockerEvents: [],
                 dockerImages: []
             };
-            yield this.execCommand('docker --version', dockerVersion)
-                .catch((error) => {
-                throw new Error("Unable to get docker version: " + error);
+            let dockerVersionOutput = yield exec.getExecOutput('docker --version');
+            if (dockerVersionOutput.exitCode != 0 || dockerVersionOutput.stderr.length > 0) {
+                core.info(`Unable to get docker version: ${dockerVersionOutput}`);
+                core.info(`Skipping container mapping since docker not found/available.`);
+                return;
+            }
+            reportData.dockerVersion = dockerVersionOutput.stdout.trim();
+            yield exec.getExecOutput('docker events --since ' + startTime + ' --until ' + new Date().toISOString() + ' --filter event=push --filter type=image --format ID={{.ID}}')
+                .then((result) => {
+                result.stdout.trim().split(os.EOL).forEach(element => {
+                    reportData.dockerEvents.push(element);
+                });
             });
-            reportData.dockerVersion = dockerVersion.join('');
             yield this.execCommand(`docker events --since ${startTime} --until ${new Date().toISOString()} --filter event=push --filter type=image --format ID={{.ID}}`, reportData.dockerEvents)
                 .catch((error) => {
                 throw new Error("Unable to get docker events: " + error);
@@ -123,20 +131,14 @@ class ContainerMapping {
     }
     execCommand(command, listener) {
         return __awaiter(this, void 0, void 0, function* () {
-            return exec.exec(command, null, {
-                listeners: {
-                    stdout: (data) => {
-                        var lines = data.toString().trim().split(os.EOL);
-                        lines.forEach(element => {
-                            listener.push(element);
-                        });
-                    }
+            return exec.getExecOutput(command)
+                .then((result) => {
+                if (result.exitCode != 0) {
+                    return Promise.reject(`Command execution failed: ${result}`);
                 }
-            })
-                .then((exitCode) => {
-                if (exitCode != 0) {
-                    Promise.reject(`Command failed with exit code ${exitCode}`);
-                }
+                result.stdout.trim().split(os.EOL).forEach(element => {
+                    listener.push(element);
+                });
             });
         });
     }

--- a/src/container-mapping.ts
+++ b/src/container-mapping.ts
@@ -22,16 +22,16 @@ export class ContainerMapping implements IMicrosoftSecurityDevOps {
      */
     public runPreJob() {
         try {
-            writeToOutStream("::group::Microsoft Defender for DevOps container mapping pre-job - https://go.microsoft.com/fwlink/?linkid=2231419");
+            core.info("::group::Microsoft Defender for DevOps container mapping pre-job - https://go.microsoft.com/fwlink/?linkid=2231419");
             this._runPreJob();
         }
         catch (error) {
             // Log the error
-            writeToOutStream("Error in Container Mapping pre-job: " + error);
+            core.info("Error in Container Mapping pre-job: " + error);
         }
         finally {
             // End the collapsible section
-            writeToOutStream("::endgroup::");
+            core.info("::endgroup::");
         }
     }
 
@@ -42,7 +42,7 @@ export class ContainerMapping implements IMicrosoftSecurityDevOps {
     private _runPreJob() {
         const startTime = new Date().toISOString();
         core.saveState('PreJobStartTime', startTime);
-        console.log('PreJobStartTime', startTime);
+        core.info(`PreJobStartTime: ${startTime}`);
     }
 
     /**
@@ -88,7 +88,7 @@ export class ContainerMapping implements IMicrosoftSecurityDevOps {
 
         // Initialize the commands 
         let dockerVersionOutput = await exec.getExecOutput('docker --version');
-        if (dockerVersionOutput.exitCode != 0 || dockerVersionOutput.stderr.length > 0) {
+        if (dockerVersionOutput.exitCode != 0) {
             core.info(`Unable to get docker version: ${dockerVersionOutput}`);
             core.info(`Skipping container mapping since docker not found/available.`);
             return;
@@ -121,6 +121,7 @@ export class ContainerMapping implements IMicrosoftSecurityDevOps {
         if (!reportSent) {
             throw new Error("Unable to send report to backend service");
         };
+        core.info("Container mapping data sent successfully.");
     }
 
     /**
@@ -141,21 +142,6 @@ export class ContainerMapping implements IMicrosoftSecurityDevOps {
                 }
             });
         });
-        // return exec.exec(command, null, {
-        //     listeners: {
-        //         stdout: (data: Buffer) => {
-        //             var lines = data.toString().trim().split(os.EOL);
-        //             lines.forEach(element => {
-        //                 listener.push(element);
-        //             });
-        //         }
-        //     }
-        // })
-        // .then((exitCode) => {
-        //     if (exitCode != 0) {
-        //         Promise.reject(`Command failed with exit code ${exitCode}`);
-        //     }
-        // });
     }
 
     /**

--- a/src/container-mapping.ts
+++ b/src/container-mapping.ts
@@ -57,14 +57,14 @@ export class ContainerMapping implements IMicrosoftSecurityDevOps {
      */
     public async runPostJob() {
         try {
-            writeToOutStream("::group::Microsoft Defender for DevOps container mapping post-job - https://go.microsoft.com/fwlink/?linkid=2231419");
+            core.info("::group::Microsoft Defender for DevOps container mapping post-job - https://go.microsoft.com/fwlink/?linkid=2231419");
             await this._runPostJob();
         } catch (error) {
             // Log the error
-            writeToOutStream("Error in Container Mapping post-job: " + error);
+            core.info("Error in Container Mapping post-job: " + error);
         } finally {
             // End the collapsible section
-            writeToOutStream("::endgroup::");
+            core.info("::endgroup::");
         }
     }
 
@@ -76,11 +76,10 @@ export class ContainerMapping implements IMicrosoftSecurityDevOps {
         let startTime = core.getState('PreJobStartTime');
         if (startTime.length <= 0) {
             startTime = new Date(new Date().getTime() - 10000).toISOString();
-            console.log(`PreJobStartTime not defined, using now-10secs`);
+            core.debug(`PreJobStartTime not defined, using now-10secs`);
         }
-        console.log(`PreJobStartTime: ${startTime}`);
+        core.info(`PreJobStartTime: ${startTime}`);
 
-        let dockerVersion = [];
         let reportData = {
             dockerVersion: "",
             dockerEvents: [],
@@ -95,21 +94,6 @@ export class ContainerMapping implements IMicrosoftSecurityDevOps {
             return;
         }
         reportData.dockerVersion = dockerVersionOutput.stdout.trim();
-
-        // await this.execCommand('docker --version', dockerVersion)
-        // .catch((error) => {
-        //     throw new Error("Unable to get docker version: " + error);
-        // });
-        // // The backend expects the docker version to be a string, not an array
-        // reportData.dockerVersion = dockerVersion.join('');
-
-        await exec.getExecOutput('docker events --since ' + startTime + ' --until ' + new Date().toISOString() + ' --filter event=push --filter type=image --format ID={{.ID}}')
-        .then((result) => {
-            
-            result.stdout.trim().split(os.EOL).forEach(element => {
-                reportData.dockerEvents.push(element);
-            });
-        });
 
         await this.execCommand(`docker events --since ${startTime} --until ${new Date().toISOString()} --filter event=push --filter type=image --format ID={{.ID}}`, reportData.dockerEvents)
         .catch((error) => {
@@ -152,7 +136,9 @@ export class ContainerMapping implements IMicrosoftSecurityDevOps {
                 return Promise.reject(`Command execution failed: ${result}`);
             }
             result.stdout.trim().split(os.EOL).forEach(element => {
-                listener.push(element);
+                if(element.length > 0) {
+                    listener.push(element);
+                }
             });
         });
         // return exec.exec(command, null, {
@@ -188,7 +174,7 @@ export class ContainerMapping implements IMicrosoftSecurityDevOps {
                 if (retryCount == 0) {
                     return false;
                 } else {
-                    writeToOutStream(`Retrying API call due to error: ${error}.\nRetry count: ${retryCount}`);
+                    core.info(`Retrying API call due to error: ${error}.\nRetry count: ${retryCount}`);
                     retryCount--;
                     return await this.sendReport(data, bearerToken, retryCount);
                 }


### PR DESCRIPTION
The client was not correctly parsing the exec-command output due to which the API call was failing. 

Eg:
> attempting to send report: {"dockerVersion":"Docker version 24.0.7, build afdd53b","dockerEvents":
**["ID=","572402417699.dkr.ecr.us-east-2.amazonaws.com/bugbash02repo:740c3002335f4adf77bdd6d83ee7daf16d55ef1c"]**
,"dockerImages":["CreatedAt=2023-11-02 16:56:17 +0000 UTC::Repo=572402417699.dkr.ecr.us-east-2.amazonaws.com/bugbash02repo::Tag=740c3002335f4adf77bdd6d83ee7daf16d55ef1c::Digest=sha256:4c932a3b56a2bf5021f6cabf57803da3eda19da7ed3b6a2b659be0258b2d3fa7","

Fixed the output and improved the logging. 
 