### PR TITLE
Update Documentation to suggest latest tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ steps:
 - uses: actions/checkout@v3
 
 - name: Run Microsoft Security DevOps
-  uses: microsoft/security-devops-action@v1
+  uses: microsoft/security-devops-action@latest
   id: msdo
 ```
 
@@ -53,7 +53,7 @@ To upload results to the Security tab of your repo, run the `github/codeql-actio
 To only run specific analyzers, use the `tools` command. This command is a comma-seperated list of tools to run. For example, to run only the `container-mapping` tool, configure this action as follows:
 
 ```yaml
-- uses: microsoft/security-devops-action@v1
+- uses: microsoft/security-devops-action@latest
   id: msdo
   with:
     tools: container-mapping

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "microsoft-security-devops-action",
-    "version": "1.10.0",
+    "version": "1.11.0",
     "description": "Node dependencies for the microsoft/security-devops-action.",
     "scripts": {
         "build": "npx gulp",


### PR DESCRIPTION
Updates the documentation examples to use the `latest` tag instead of `v1`