### PR TITLE
Update CodeQL upload-sarif step

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To upload results to the Security tab of your repo, run the `github/codeql-actio
 
 ```yaml
 - name: Upload results to Security tab
-  uses: github/codeql-action/upload-sarif@v2
+  uses: github/codeql-action/upload-sarif@v3
   with:
     sarif_file: ${{ steps.msdo.outputs.sarifFile }}
 ```


### PR DESCRIPTION
CodeQL version 2 is deprecated:
https://github.blog/changelog/2025-01-10-code-scanning-codeql-action-v2-is-now-deprecated/