### PR TITLE
feat: add break-on-detections input for build failure on vulnerabilities

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,9 @@ inputs:
     description: A comma separated list of analyzer to run. Example bandit, binskim, container-mapping, eslint, templateanalyzer, terrascan, trivy.
   includeTools:
     description: Deprecated
+  break-on-detections:
+    description: If true, the action will fail the build when vulnerabilities are detected at or above the configured severity. Requires toolkit support for MSDO_BREAK.
+    default: 'false'
   existingFilename:
     description: A SARIF filename that already exists. If it does, then the normal run will not take place and the file will instead be uploaded to MSDO backend.
 outputs:

--- a/lib/msdo.js
+++ b/lib/msdo.js
@@ -112,6 +112,11 @@ class MicrosoftSecurityDevOps {
                 }
                 args.push('--github');
             }
+            let breakOnDetections = core.getInput('break-on-detections');
+            if (breakOnDetections && breakOnDetections.trim().toUpperCase() === 'TRUE') {
+                process.env.MSDO_BREAK = 'true';
+                core.debug('break-on-detections is enabled, set MSDO_BREAK=true');
+            }
             yield client.run(args, 'microsoft/security-devops-action');
         });
     }

--- a/src/msdo.ts
+++ b/src/msdo.ts
@@ -97,6 +97,12 @@ export class MicrosoftSecurityDevOps implements IMicrosoftSecurityDevOps {
             args.push('--github');
         }
 
+        let breakOnDetections: string = core.getInput('break-on-detections');
+        if (breakOnDetections && breakOnDetections.trim().toUpperCase() === 'TRUE') {
+            process.env.MSDO_BREAK = 'true';
+            core.debug('break-on-detections is enabled, set MSDO_BREAK=true');
+        }
+
         await client.run(args, 'microsoft/security-devops-action');
     }
 }


### PR DESCRIPTION
## Summary
- Adds `break-on-detections` input (default: false) to `action.yml`
- When enabled, sets `MSDO_BREAK=true` env var before calling toolkit's `client.run()`
- Closes https://github.com/microsoft/security-devops-action/issues/156

## Dependency
Requires toolkit PR: https://github.com/microsoft/security-devops-actions-toolkit/pull/23
(The toolkit must respect `MSDO_BREAK` to skip `--not-break-on-detections`)

## Usage
```yaml
- uses: microsoft/security-devops-action@main
  with:
    break-on-detections: true
```

## Backward compatible
Default is `false` — no behavior change unless user explicitly opts in.

## Test plan
- [ ] Default (false): no change in behavior
- [ ] Enabled (true): `MSDO_BREAK=true` set, toolkit skips `--not-break-on-detections`
- [ ] Works with existing inputs (tools, categories, etc.)

ADO: AB#36807380