### PR TITLE
fix(ci): resolve upload-artifact 409 conflict on matrix runs

### DIFF
--- a/.github/workflows/on-push-verification.yml
+++ b/.github/workflows/on-push-verification.yml
@@ -38,5 +38,5 @@ jobs:
     - name: Upload alerts file as a workflow artifact
       uses: actions/upload-artifact@v4
       with:  
-        name: alerts
+        name: alerts-${{ matrix.os }}
         path: ${{ steps.msdo.outputs.sarifFile }}


### PR DESCRIPTION
## Summary
- Appends `matrix.os` to artifact name (`alerts` → `alerts-windows-latest` / `alerts-ubuntu-latest`)
- Fixes 409 Conflict error when both matrix jobs try to upload an artifact with the same name

## Root cause
`actions/upload-artifact@v4` does not allow overwriting — each artifact name must be unique per workflow run. The matrix runs both tried to upload `alerts`.