### PR TITLE
fix(ci): append matrix OS to artifact name in sample-workflow

### DIFF
--- a/.github/workflows/sample-workflow.yml
+++ b/.github/workflows/sample-workflow.yml
@@ -37,5 +37,5 @@ jobs:
     - name: Upload alerts file as a workflow artifact
       uses: actions/upload-artifact@v4
       with:  
-        name: alerts
+        name: alerts-${{ matrix.os }}
         path: ${{ steps.msdo.outputs.sarifFile }}


### PR DESCRIPTION
## Summary
- Fix duplicate artifact upload conflict in `sample-workflow.yml` (runs on main)
- Same fix as #128 for `on-push-verification.yml`, but for the sample workflow
- `upload-artifact@v4` rejects duplicate names within the same run, causing the Windows matrix job to fail with 409

## Change
`name: alerts` → `name: alerts-${{ matrix.os }}` so each matrix job uploads a uniquely named artifact.

## Test plan
- [ ] CI passes on both `windows-latest` and `ubuntu-latest` matrix jobs