### PR TITLE
fix(ci): disable issue creation on agentic workflow no-op

### DIFF
--- a/.github/workflows/msdo-issue-assistant.lock.yml
+++ b/.github/workflows/msdo-issue-assistant.lock.yml
@@ -22,7 +22,7 @@
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
 #
-# frontmatter-hash: 4328471ec936d196d8e3cd83c860cc670827d9b785cf7e2faac6827c1f4c9dd0
+# frontmatter-hash: 345fd8e52701d2e1b67e60e716bf3ca3defe3dfaf6f7311778a99a4e652947ff
 
 name: "MSDO Issue Triage Assistant"
 "on":
@@ -32,7 +32,6 @@ name: "MSDO Issue Triage Assistant"
   issues:
     types:
     - opened
-    - reopened
   workflow_dispatch:
 
 permissions: {}
@@ -189,7 +188,7 @@ jobs:
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
           cat > /opt/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_EOF'
-          {"add_comment":{"max":4},"add_labels":{"allowed":["bug","feature","enhancement","documentation","question","needs-info","needs-maintainer"],"max":3},"missing_data":{},"missing_tool":{},"noop":{"max":1}}
+          {"add_comment":{"max":4},"add_labels":{"allowed":["bug","feature","enhancement","documentation","question","needs-info","needs-maintainer"],"max":3},"missing_data":{},"missing_tool":{}}
           GH_AW_SAFE_OUTPUTS_CONFIG_EOF
           cat > /opt/gh-aw/safeoutputs/tools.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_EOF'
           [
@@ -259,23 +258,6 @@ jobs:
                 "type": "object"
               },
               "name": "missing_tool"
-            },
-            {
-              "description": "Log a transparency message when no significant actions are needed. Use this to confirm workflow completion and provide visibility when analysis is complete but no changes or outputs are required (e.g., 'No issues found', 'All checks passed'). This ensures the workflow produces human-visible output even when no other actions are taken.",
-              "inputSchema": {
-                "additionalProperties": false,
-                "properties": {
-                  "message": {
-                    "description": "Status or completion message to log. Should explain what was analyzed and the outcome (e.g., 'Code review complete - no issues found', 'Analysis complete - all tests passing').",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "message"
-                ],
-                "type": "object"
-              },
-              "name": "noop"
             },
             {
               "description": "Report that data or information needed to complete the task is not available. Use this when you cannot accomplish what was requested because required data, context, or information is missing.",
@@ -355,17 +337,6 @@ jobs:
                   "type": "string",
                   "sanitize": true,
                   "maxLength": 128
-                }
-              }
-            },
-            "noop": {
-              "defaultMax": 1,
-              "fields": {
-                "message": {
-                  "required": true,
-                  "type": "string",
-                  "sanitize": true,
-                  "maxLength": 65000
                 }
               }
             }
@@ -776,7 +747,6 @@ jobs:
       issues: write
       pull-requests: write
     outputs:
-      noop_message: ${{ steps.noop.outputs.noop_message }}
       tools_reported: ${{ steps.missing_tool.outputs.tools_reported }}
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
@@ -795,20 +765,6 @@ jobs:
           mkdir -p /tmp/gh-aw/safeoutputs/
           find "/tmp/gh-aw/safeoutputs/" -type f -print
           echo "GH_AW_AGENT_OUTPUT=/tmp/gh-aw/safeoutputs/agent_output.json" >> "$GITHUB_ENV"
-      - name: Process No-Op Messages
-        id: noop
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
-        env:
-          GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
-          GH_AW_NOOP_MAX: 1
-          GH_AW_WORKFLOW_NAME: "MSDO Issue Triage Assistant"
-        with:
-          github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
-          script: |
-            const { setupGlobals } = require('/opt/gh-aw/actions/setup_globals.cjs');
-            setupGlobals(core, github, context, exec, io);
-            const { main } = require('/opt/gh-aw/actions/noop.cjs');
-            await main();
       - name: Record Missing Tool
         id: missing_tool
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -848,8 +804,6 @@ jobs:
           GH_AW_WORKFLOW_NAME: "MSDO Issue Triage Assistant"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
-          GH_AW_NOOP_MESSAGE: ${{ steps.noop.outputs.noop_message }}
-          GH_AW_NOOP_REPORT_AS_ISSUE: "true"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/msdo-issue-assistant.md
+++ b/.github/workflows/msdo-issue-assistant.md
@@ -4,7 +4,7 @@
 
 on:
   issues:
-    types: [opened, reopened]
+    types: [opened]
   issue_comment:
     types: [created]
   workflow_dispatch:
@@ -29,6 +29,7 @@ tools:
       - raw.githubusercontent.com
 
 safe-outputs:
+  noop: false
   add-comment:
     max: 4
   add-labels:
@@ -107,6 +108,7 @@ Keep responses:
 3. **Stay on topic** - Only respond to issues related to MSDO, security-devops-action, or the supported security tools. If an issue is unrelated (e.g. general GitHub Actions questions, unrelated security tools, off-topic discussions), do not respond.
 4. **Don't respond** if:
    - The issue is not related to MSDO or security-devops-action
+   - The issue is closed
    - The commenter is not the issue author (unless it's a new issue)
    - You've already responded twice and there is no new technical information in the latest user message
    - The issue has a `needs-maintainer` label (a maintainer is handling it)


### PR DESCRIPTION
## Summary
- Set `GH_AW_NOOP_REPORT_AS_ISSUE` to `false` to stop creating issues when the agent decides not to respond
- Downgraded conclusion job permissions from `write` to `read` for issues, discussions, and pull-requests to prevent any unwanted issue creation from handler scripts

## Test plan
- [ ] Trigger agentic workflow with an off-topic issue and verify no new issue is created
- [ ] Trigger agentic workflow with a valid MSDO issue and verify comments/labels still work (safe_outputs job retains write permissions)