### PR TITLE
Add declarative label taxonomy

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,143 @@
+# =============================================================================
+# Label Taxonomy for microsoft/security-devops-action
+# =============================================================================
+# Synced by .github/workflows/sync-labels.yml using micnncim/action-label-syncer
+#
+# Naming convention: <group>:<value> (lowercase, kebab-case)
+# Color convention:  consistent within each group for at-a-glance filtering
+#
+# To propose changes, edit this file and open a PR.
+# =============================================================================
+
+# ---------------------------------------------------------------------------
+# Type — what kind of issue / PR
+# ---------------------------------------------------------------------------
+- name: "type:bug"
+  description: "Something isn't working"
+  color: "d73a4a"
+
+- name: "type:feature"
+  description: "New feature or request"
+  color: "a2eeef"
+
+- name: "type:docs"
+  description: "Improvements or additions to documentation"
+  color: "0075ca"
+
+- name: "type:question"
+  description: "General question or support request"
+  color: "d876e3"
+
+- name: "type:security"
+  description: "Security vulnerability or hardening"
+  color: "e11d48"
+
+- name: "type:maintenance"
+  description: "Dependency updates, refactoring, chores"
+  color: "bfd4f2"
+
+# ---------------------------------------------------------------------------
+# Priority — how urgent
+# ---------------------------------------------------------------------------
+- name: "priority:critical"
+  description: "Blocking issue, needs immediate fix"
+  color: "b60205"
+
+- name: "priority:high"
+  description: "Important, should be addressed soon"
+  color: "d93f0b"
+
+- name: "priority:medium"
+  description: "Normal priority"
+  color: "fbca04"
+
+- name: "priority:low"
+  description: "Nice to have, address when convenient"
+  color: "0e8a16"
+
+# ---------------------------------------------------------------------------
+# Status — where in the workflow
+# ---------------------------------------------------------------------------
+- name: "status:triage"
+  description: "Needs initial triage and classification"
+  color: "f9d0c4"
+
+- name: "status:waiting-on-author"
+  description: "Waiting for more information from author"
+  color: "f9d0c4"
+
+- name: "status:repro-needed"
+  description: "Bug needs reproduction steps"
+  color: "f9d0c4"
+
+- name: "status:team-review"
+  description: "Queued for team review and decision"
+  color: "d93f0b"
+
+- name: "status:approved"
+  description: "Accepted, ready to be worked on"
+  color: "0e8a16"
+
+- name: "status:blocked"
+  description: "Blocked by external dependency or decision"
+  color: "b60205"
+
+- name: "status:inactive"
+  description: "No activity for an extended period"
+  color: "cfd3d7"
+
+# ---------------------------------------------------------------------------
+# Area — what component
+# ---------------------------------------------------------------------------
+- name: "area:action"
+  description: "GitHub Action definition, inputs, and outputs"
+  color: "c5def5"
+
+- name: "area:msdo-cli"
+  description: "MSDO CLI integration and execution"
+  color: "c5def5"
+
+- name: "area:container-mapping"
+  description: "Container image mapping functionality"
+  color: "c5def5"
+
+- name: "area:ci"
+  description: "CI/CD pipeline and workflows"
+  color: "c5def5"
+
+# ---------------------------------------------------------------------------
+# Resolution — how it was closed
+# ---------------------------------------------------------------------------
+- name: "resolution:duplicate"
+  description: "This issue or pull request already exists"
+  color: "cfd3d7"
+
+- name: "resolution:wontfix"
+  description: "This will not be worked on"
+  color: "eeeeee"
+
+- name: "resolution:invalid"
+  description: "Not a valid issue"
+  color: "e4e669"
+
+- name: "resolution:by-design"
+  description: "Working as intended"
+  color: "cfd3d7"
+
+# ---------------------------------------------------------------------------
+# Community
+# ---------------------------------------------------------------------------
+- name: "good first issue"
+  description: "Good for newcomers"
+  color: "7057ff"
+
+- name: "help wanted"
+  description: "Extra attention is needed"
+  color: "008672"
+
+# ---------------------------------------------------------------------------
+# Special
+# ---------------------------------------------------------------------------
+- name: "agentic-workflows"
+  description: "Related to GitHub Agentic Workflows"
+  color: "1d76db"

--- a/.github/workflows/msdo-issue-assistant.lock.yml
+++ b/.github/workflows/msdo-issue-assistant.lock.yml
@@ -22,7 +22,7 @@
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
 #
-# frontmatter-hash: 80102642ae6a7c0c1f7d98b9b60a76c4d412db4ed3c5e25d44151b438f391379
+# frontmatter-hash: ec5b4527a6199a05f3a36752477dac71dd9eaaa688d63482f19275f580ae9b5f
 
 name: "MSDO Issue Triage Assistant"
 "on":
@@ -186,7 +186,7 @@ jobs:
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
           cat > /opt/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_EOF'
-          {"add_comment":{"max":4},"add_labels":{"allowed":["bug","feature","enhancement","documentation","question","needs-info","needs-maintainer"],"max":3},"missing_data":{},"missing_tool":{}}
+          {"add_comment":{"max":4},"add_labels":{"allowed":["type:bug","type:feature","type:docs","type:question","type:security","type:maintenance","status:triage","status:waiting-on-author","status:repro-needed","status:team-review"],"max":3},"missing_data":{},"missing_tool":{}}
           GH_AW_SAFE_OUTPUTS_CONFIG_EOF
           cat > /opt/gh-aw/safeoutputs/tools.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_EOF'
           [
@@ -212,7 +212,7 @@ jobs:
               "name": "add_comment"
             },
             {
-              "description": "Add labels to an existing GitHub issue or pull request for categorization and filtering. Labels must already exist in the repository. For creating new issues with labels, use create_issue with the labels property instead. CONSTRAINTS: Only these labels are allowed: [bug feature enhancement documentation question needs-info needs-maintainer].",
+              "description": "Add labels to an existing GitHub issue or pull request for categorization and filtering. Labels must already exist in the repository. For creating new issues with labels, use create_issue with the labels property instead. CONSTRAINTS: Only these labels are allowed: [type:bug type:feature type:docs type:question type:security type:maintenance status:triage status:waiting-on-author status:repro-needed status:team-review].",
               "inputSchema": {
                 "additionalProperties": false,
                 "properties": {
@@ -969,7 +969,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":4},\"add_labels\":{\"allowed\":[\"bug\",\"feature\",\"enhancement\",\"documentation\",\"question\",\"needs-info\",\"needs-maintainer\"]},\"missing_data\":{},\"missing_tool\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":4},\"add_labels\":{\"allowed\":[\"type:bug\",\"type:feature\",\"type:docs\",\"type:question\",\"type:security\",\"type:maintenance\",\"status:triage\",\"status:waiting-on-author\",\"status:repro-needed\",\"status:team-review\"]},\"missing_data\":{},\"missing_tool\":{}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/msdo-issue-assistant.md
+++ b/.github/workflows/msdo-issue-assistant.md
@@ -35,7 +35,7 @@ safe-outputs:
   add-comment:
     max: 4
   add-labels:
-    allowed: [bug, feature, enhancement, documentation, question, needs-info, needs-maintainer]
+    allowed: ["type:bug", "type:feature", "type:docs", "type:question", "type:security", "type:maintenance", "status:triage", "status:waiting-on-author", "status:repro-needed", "status:team-review"]
 
 ---
 
@@ -77,7 +77,7 @@ When a new issue is opened or a user comments:
 **If the wiki answers the question:**
 - Provide the solution directly from wiki knowledge
 - Include relevant wiki links
-- Add appropriate label (bug, feature, documentation, question)
+- Add appropriate label (`type:bug`, `type:feature`, `type:docs`, `type:question`)
 
 **If more information is needed:**
 - Ask for specific details (max 3-4 items):
@@ -85,12 +85,12 @@ When a new issue is opened or a user comments:
   - Operating system and runner type
   - Error message or logs
   - Workflow YAML configuration
-- Add the `needs-info` label
+- Add the `status:waiting-on-author` label
 
 **If the issue requires maintainer attention:**
 - Summarize what you understand about the issue
 - Explain why a maintainer needs to look at it
-- Add the `needs-maintainer` label
+- Add the `status:team-review` label
 
 ### Step 3: Format Your Response
 
@@ -113,7 +113,7 @@ Keep responses:
    - The issue is closed
    - The commenter is not the issue author (unless it's a new issue)
    - You've already responded twice and there is no new technical information in the latest user message
-   - The issue has a `needs-maintainer` label (a maintainer is handling it)
+   - The issue has a `status:team-review` label (a maintainer is handling it)
 5. **Be honest** - if you don't know something, say so and suggest checking the wiki or waiting for a maintainer
 
 ## Response Examples
@@ -129,7 +129,7 @@ Keep responses:
 **Off-topic issue:** "How do I set up GitHub Actions for deploying to AWS?"
 → Do not respond. This is unrelated to MSDO.
 
-**Issue labeled `needs-maintainer`:** Any issue with this label.
+**Issue labeled `status:team-review`:** Any issue with this label.
 → Do not respond. A maintainer is already handling it.
 
 **Repeated comments with no new info:** User says "Any update?" or "bump" after you already responded.


### PR DESCRIPTION
## Summary
- Adds `.github/labels.yml` as the source of truth for repository label definitions
- Updates agentic workflow to use new taxonomy labels instead of legacy names
- Labels have already been created directly on the repo via the GitHub API

## Changes
- `labels.yml`: Full taxonomy — type, priority, status, area, resolution, community, special
- `msdo-issue-assistant.md`: `add-labels.allowed` updated to new taxonomy (`type:bug`, `status:waiting-on-author`, `status:team-review`, etc.)
- `msdo-issue-assistant.lock.yml`: Recompiled

## Notes
- No sync workflow needed — labels are managed directly via API