### PR TITLE
fix(ci): disable lockdown mode for CI Doctor

### DIFF
--- a/.github/workflows/ci-doctor.lock.yml
+++ b/.github/workflows/ci-doctor.lock.yml
@@ -22,7 +22,7 @@
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
 #
-# frontmatter-hash: 7396a89eee35dd3034c6c7a015a9459ae192ec5858fd346e43953a501b9ea9c7
+# frontmatter-hash: c9666efbc02df1203e30cb36336b938b70894f48c58634c5bb84b713c1d0a3f9
 
 name: "CI Doctor"
 "on":
@@ -189,17 +189,6 @@ jobs:
         run: /opt/gh-aw/actions/install_copilot_cli.sh 0.0.409
       - name: Install awf binary
         run: bash /opt/gh-aw/actions/install_awf_binary.sh v0.17.0
-      - name: Validate lockdown mode requirements
-        id: validate-lockdown-requirements
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
-        env:
-          GITHUB_MCP_LOCKDOWN_EXPLICIT: "true"
-          GH_AW_GITHUB_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
-          GH_AW_GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN }}
-        with:
-          script: |
-            const validateLockdownRequirements = require('/opt/gh-aw/actions/validate_lockdown_requirements.cjs');
-            validateLockdownRequirements(core);
       - name: Download container images
         run: bash /opt/gh-aw/actions/download_docker_images.sh ghcr.io/github/gh-aw-firewall/agent:0.17.0 ghcr.io/github/gh-aw-firewall/squid:0.17.0 ghcr.io/github/gh-aw-mcpg:v0.1.4 ghcr.io/github/github-mcp-server:v0.30.3 node:lts-alpine
       - name: Write Safe Outputs Config
@@ -568,7 +557,6 @@ jobs:
                 "type": "stdio",
                 "container": "ghcr.io/github/github-mcp-server:v0.30.3",
                 "env": {
-                  "GITHUB_LOCKDOWN_MODE": "1",
                   "GITHUB_PERSONAL_ACCESS_TOKEN": "\${GITHUB_MCP_SERVER_TOKEN}",
                   "GITHUB_READ_ONLY": "1",
                   "GITHUB_TOOLSETS": "issues,actions"

--- a/.github/workflows/ci-doctor.md
+++ b/.github/workflows/ci-doctor.md
@@ -25,7 +25,7 @@ network:
 
 tools:
   github:
-    lockdown: true
+    lockdown: false
     toolsets: [issues, actions]
   fetch:
     allowed-domains: []


### PR DESCRIPTION
## Summary
- Disable `lockdown: true` for CI Doctor — it requires a dedicated PAT (`GH_AW_GITHUB_TOKEN`) which isn't configured
- Set `lockdown: false` to match the existing triage workflow pattern
- Agent is still constrained by `safe-outputs` (1 issue max, specific labels, no comments, no PRs)

## Test plan
- [x] `gh aw compile` succeeds
- [x] Verified lockdown error on previous run
- [x] Matches triage workflow security pattern (`lockdown: false` + `safe-outputs`)