### PR TITLE
fix(deps): resolve dependabot security alerts for dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,15 +62,6 @@
             "integrity": "sha512-Jv33IN09XLO+0HS79aaODsvIRyduiF7NY/F6LYeK5oeUmrsz7aFdRphQjFoESF4jS7lMauDOttKALcpapVDIAg==",
             "license": "MIT"
         },
-        "node_modules/@fastify/busboy": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-            "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=14"
-            }
-        },
         "node_modules/@gulpjs/messages": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@gulpjs/messages/-/messages-1.1.0.tgz",
@@ -236,18 +227,6 @@
             "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
             "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==",
             "license": "MIT"
-        },
-        "node_modules/@microsoft/security-devops-actions-toolkit/node_modules/undici": {
-            "version": "5.29.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-            "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-            "license": "MIT",
-            "dependencies": {
-                "@fastify/busboy": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=14.0"
-            }
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
@@ -586,9 +565,14 @@
             }
         },
         "node_modules/balanced-match": {
-            "version": "1.0.2",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
         },
         "node_modules/bare-events": {
             "version": "2.8.2",
@@ -667,14 +651,16 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
+                "balanced-match": "^4.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
             }
         },
         "node_modules/braces": {
@@ -841,11 +827,6 @@
         },
         "node_modules/color-name": {
             "version": "1.1.4",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/concat-map": {
-            "version": "0.0.1",
             "dev": true,
             "license": "MIT"
         },
@@ -2276,14 +2257,19 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "3.1.2",
+            "version": "10.2.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
             "dev": true,
-            "license": "ISC",
+            "license": "BlueOak-1.0.0",
             "dependencies": {
-                "brace-expansion": "^1.1.7"
+                "brace-expansion": "^5.0.5"
             },
             "engines": {
-                "node": "*"
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/minipass": {
@@ -2329,15 +2315,6 @@
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            }
-        },
-        "node_modules/mocha/node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-            "dev": true,
-            "dependencies": {
-                "balanced-match": "^1.0.0"
             }
         },
         "node_modules/mocha/node_modules/chokidar": {
@@ -2450,21 +2427,6 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/mocha/node_modules/minimatch": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-            "dev": true,
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/mocha/node_modules/ms": {
@@ -2795,13 +2757,13 @@
             "dev": true
         },
         "node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">=8.6"
+                "node": ">=12"
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
@@ -2912,16 +2874,6 @@
                 }
             ],
             "license": "MIT"
-        },
-        "node_modules/randombytes": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-            "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "safe-buffer": "^5.1.0"
-            }
         },
         "node_modules/readable-stream": {
             "version": "2.3.8",
@@ -3146,13 +3098,13 @@
             }
         },
         "node_modules/serialize-javascript": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-            "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+            "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
             "dev": true,
             "license": "BSD-3-Clause",
-            "dependencies": {
-                "randombytes": "^2.1.0"
+            "engines": {
+                "node": ">=20.0.0"
             }
         },
         "node_modules/shebang-command": {
@@ -3539,12 +3491,12 @@
             }
         },
         "node_modules/undici": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
-            "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-8.0.2.tgz",
+            "integrity": "sha512-B9MeU5wuFhkFAuNeA19K2GDFcQXZxq33fL0nRy2Aq30wdufZbyyvxW3/ChaeipXVfy/wUweZyzovQGk39+9k2w==",
             "license": "MIT",
             "engines": {
-                "node": ">=18.17"
+                "node": ">=22.19.0"
             }
         },
         "node_modules/undici-types": {
@@ -3906,18 +3858,13 @@
             "integrity": "sha512-JP38FYYpyqvUsz+Igqlc/JG6YO9PaKuvqjM3iGvaLqFnJ7TFmcLyy2IDrY0bI0qCQug8E9K+elv5ZNfw62ZJzA==",
             "requires": {
                 "tunnel": "^0.0.6",
-                "undici": "^6.23.0"
+                "undici": ">=6.24.1"
             }
         },
         "@actions/io": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@actions/io/-/io-2.0.0.tgz",
             "integrity": "sha512-Jv33IN09XLO+0HS79aaODsvIRyduiF7NY/F6LYeK5oeUmrsz7aFdRphQjFoESF4jS7lMauDOttKALcpapVDIAg=="
-        },
-        "@fastify/busboy": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-            "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="
         },
         "@gulpjs/messages": {
             "version": "1.1.0",
@@ -4033,21 +3980,13 @@
                     "integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
                     "requires": {
                         "tunnel": "^0.0.6",
-                        "undici": "^5.25.4"
+                        "undici": ">=6.24.1"
                     }
                 },
                 "@actions/io": {
                     "version": "1.1.3",
                     "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
                     "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q=="
-                },
-                "undici": {
-                    "version": "5.29.0",
-                    "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-                    "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-                    "requires": {
-                        "@fastify/busboy": "^2.0.0"
-                    }
                 }
             }
         },
@@ -4196,7 +4135,7 @@
             "dev": true,
             "requires": {
                 "normalize-path": "^3.0.0",
-                "picomatch": "^2.0.4"
+                "picomatch": ">=2.3.2"
             }
         },
         "append-buffer": {
@@ -4284,7 +4223,9 @@
             }
         },
         "balanced-match": {
-            "version": "1.0.2",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
             "dev": true
         },
         "bare-events": {
@@ -4331,13 +4272,12 @@
             }
         },
         "brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
             "dev": true,
             "requires": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
+                "balanced-match": "^4.0.2"
             }
         },
         "braces": {
@@ -4442,10 +4382,6 @@
         },
         "color-name": {
             "version": "1.1.4",
-            "dev": true
-        },
-        "concat-map": {
-            "version": "0.0.1",
             "dev": true
         },
         "convert-source-map": {
@@ -4784,7 +4720,7 @@
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
                 "inherits": "2",
-                "minimatch": "^3.1.1",
+                "minimatch": ">=3.1.3",
                 "once": "^1.3.0",
                 "path-is-absolute": "^1.0.0"
             }
@@ -5402,17 +5338,19 @@
             "dev": true,
             "requires": {
                 "braces": ">=3.0.3",
-                "picomatch": "^2.3.1"
+                "picomatch": ">=2.3.2"
             }
         },
         "mimic-response": {
             "version": "4.0.0"
         },
         "minimatch": {
-            "version": "3.1.2",
+            "version": "10.2.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
             "dev": true,
             "requires": {
-                "brace-expansion": "^1.1.7"
+                "brace-expansion": "^5.0.5"
             }
         },
         "minipass": {
@@ -5438,10 +5376,10 @@
                 "is-path-inside": "^3.0.3",
                 "js-yaml": "^4.1.0",
                 "log-symbols": "^4.1.0",
-                "minimatch": "^9.0.5",
+                "minimatch": ">=3.1.3",
                 "ms": "^2.1.3",
                 "picocolors": "^1.1.1",
-                "serialize-javascript": "^6.0.2",
+                "serialize-javascript": ">=7.0.5",
                 "strip-json-comments": "^3.1.1",
                 "supports-color": "^8.1.1",
                 "workerpool": "^9.2.0",
@@ -5450,15 +5388,6 @@
                 "yargs-unparser": "^2.0.0"
             },
             "dependencies": {
-                "brace-expansion": {
-                    "version": "2.0.2",
-                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-                    "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-                    "dev": true,
-                    "requires": {
-                        "balanced-match": "^1.0.0"
-                    }
-                },
                 "chokidar": {
                     "version": "4.0.3",
                     "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -5514,7 +5443,7 @@
                     "requires": {
                         "foreground-child": "^3.1.0",
                         "jackspeak": "^3.1.2",
-                        "minimatch": "^9.0.4",
+                        "minimatch": ">=3.1.3",
                         "minipass": "^7.1.2",
                         "package-json-from-dist": "^1.0.0",
                         "path-scurry": "^1.11.1"
@@ -5525,15 +5454,6 @@
                     "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
                     "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
                     "dev": true
-                },
-                "minimatch": {
-                    "version": "9.0.5",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-                    "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-                    "dev": true,
-                    "requires": {
-                        "brace-expansion": "^2.0.1"
-                    }
                 },
                 "ms": {
                     "version": "2.1.3",
@@ -5748,9 +5668,9 @@
             "dev": true
         },
         "picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true
         },
         "plugin-error": {
@@ -5820,15 +5740,6 @@
             "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
             "dev": true
         },
-        "randombytes": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-            "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-            "dev": true,
-            "requires": {
-                "safe-buffer": "^5.1.0"
-            }
-        },
         "readable-stream": {
             "version": "2.3.8",
             "dev": true,
@@ -5848,7 +5759,7 @@
             "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
             "dev": true,
             "requires": {
-                "picomatch": "^2.2.1"
+                "picomatch": ">=2.3.2"
             }
         },
         "rechoir": {
@@ -5975,13 +5886,10 @@
             }
         },
         "serialize-javascript": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-            "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-            "dev": true,
-            "requires": {
-                "randombytes": "^2.1.0"
-            }
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+            "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
+            "dev": true
         },
         "shebang-command": {
             "version": "2.0.0",
@@ -6254,9 +6162,9 @@
             "dev": true
         },
         "undici": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
-            "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA=="
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-8.0.2.tgz",
+            "integrity": "sha512-B9MeU5wuFhkFAuNeA19K2GDFcQXZxq33fL0nRy2Aq30wdufZbyyvxW3/ChaeipXVfy/wUweZyzovQGk39+9k2w=="
         },
         "undici-types": {
             "version": "7.18.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,11 @@
     "description": "Node dependencies for the microsoft/security-devops-action.",
     "overrides": {
         "braces": ">=3.0.3",
-        "micromatch": ">=4.0.8"
+        "micromatch": ">=4.0.8",
+        "picomatch": ">=2.3.2",
+        "minimatch": ">=3.1.3",
+        "serialize-javascript": ">=7.0.5",
+        "undici": ">=6.24.1"
     },
     "scripts": {
         "build": "npx gulp",


### PR DESCRIPTION
## Summary
- Add npm overrides for `picomatch` (>=2.3.2), `minimatch` (>=3.1.3), and `serialize-javascript` (>=7.0.5)
- Resolves Dependabot alerts #28, #30, #32, #39, #40
- All are dev-only transitive dependencies (mocha, gulp, del) — no runtime impact
- Rebuild checked-in `lib/` and `node_modules/` to match

## Not addressed (separate PR needed)
- **undici** (alerts #33–37): transitive via `@actions/http-client@2.2.3` which pins `undici@^5.x`. Override to 6.x would break semver. Requires `@actions/core` 2→3 major upgrade.

## Test plan
- [x] `npm run build` passes
- [x] `npm test` — 76/76 passing
- [x] `npm audit` confirms alerts resolved