### PR TITLE
feat(bot): add tool configuration knowledge to triage bot

### DIFF
--- a/.github/workflows/msdo-issue-assistant.lock.yml
+++ b/.github/workflows/msdo-issue-assistant.lock.yml
@@ -21,7 +21,7 @@
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"be9d9a34c65ac1897e69366960562c46d72ff703a7ca2bcec2adf25f114a1707","compiler_version":"v0.61.0","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"b9853605bc6fd41a4d81ec4728106d1ffdc01e2dbcf460d6aaea1620c94a3367","compiler_version":"v0.61.0","strict":true}
 
 name: "MSDO Issue Triage Assistant"
 "on":
@@ -251,7 +251,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      issues: write
+      issues: read
     env:
       DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       GH_AW_ASSETS_ALLOWED_EXTS: ""
@@ -336,7 +336,7 @@ jobs:
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
           cat > /opt/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_EOF'
-          {"add_comment":{"max":4},"add_labels":{"allowed":["type:bug","type:feature","type:docs","type:question","type:security","type:maintenance","status:triage","status:waiting-on-author","status:repro-needed","status:team-review"],"max":3},"missing_data":{},"missing_tool":{}}
+          {"add_comment":{"max":4},"add_labels":{"allowed":["type:bug","type:feature","type:docs","type:question","type:security","type:maintenance","status:triage","status:waiting-on-author","status:repro-needed","status:team-review","area:action","area:msdo-cli","area:ci","area:container-mapping"],"max":3},"missing_data":{},"missing_tool":{}}
           GH_AW_SAFE_OUTPUTS_CONFIG_EOF
       - name: Write Safe Outputs Tools
         run: |
@@ -344,7 +344,7 @@ jobs:
           {
             "description_suffixes": {
               "add_comment": " CONSTRAINTS: Maximum 4 comment(s) can be added.",
-              "add_labels": " CONSTRAINTS: Only these labels are allowed: [\"type:bug\" \"type:feature\" \"type:docs\" \"type:question\" \"type:security\" \"type:maintenance\" \"status:triage\" \"status:waiting-on-author\" \"status:repro-needed\" \"status:team-review\"]."
+              "add_labels": " CONSTRAINTS: Only these labels are allowed: [\"type:bug\" \"type:feature\" \"type:docs\" \"type:question\" \"type:security\" \"type:maintenance\" \"status:triage\" \"status:waiting-on-author\" \"status:repro-needed\" \"status:team-review\" \"area:action\" \"area:msdo-cli\" \"area:ci\" \"area:container-mapping\"]."
             },
             "repo_params": {},
             "dynamic_tools": []
@@ -981,7 +981,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,codeload.github.com,docs.github.com,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,host.docker.internal,lfs.github.com,objects.githubusercontent.com,raw.githubusercontent.com,registry.npmjs.org,telemetry.enterprise.githubcopilot.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":4},\"add_labels\":{\"allowed\":[\"type:bug\",\"type:feature\",\"type:docs\",\"type:question\",\"type:security\",\"type:maintenance\",\"status:triage\",\"status:waiting-on-author\",\"status:repro-needed\",\"status:team-review\"]},\"missing_data\":{},\"missing_tool\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":4},\"add_labels\":{\"allowed\":[\"type:bug\",\"type:feature\",\"type:docs\",\"type:question\",\"type:security\",\"type:maintenance\",\"status:triage\",\"status:waiting-on-author\",\"status:repro-needed\",\"status:team-review\",\"area:action\",\"area:msdo-cli\",\"area:ci\",\"area:container-mapping\"]},\"missing_data\":{},\"missing_tool\":{}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/msdo-issue-assistant.lock.yml
+++ b/.github/workflows/msdo-issue-assistant.lock.yml
@@ -251,7 +251,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      issues: read
+      issues: write
     env:
       DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       GH_AW_ASSETS_ALLOWED_EXTS: ""

--- a/.github/workflows/msdo-issue-assistant.md
+++ b/.github/workflows/msdo-issue-assistant.md
@@ -34,7 +34,7 @@ safe-outputs:
   add-comment:
     max: 4
   add-labels:
-    allowed: ["type:bug", "type:feature", "type:docs", "type:question", "type:security", "type:maintenance", "status:triage", "status:waiting-on-author", "status:repro-needed", "status:team-review"]
+    allowed: ["type:bug", "type:feature", "type:docs", "type:question", "type:security", "type:maintenance", "status:triage", "status:waiting-on-author", "status:repro-needed", "status:team-review", "area:action", "area:msdo-cli", "area:ci", "area:container-mapping"]
 
 ---
 
@@ -44,9 +44,10 @@ You are an issue triage assistant for the **Microsoft Security DevOps (MSDO)** C
 
 ## Your Knowledge Base
 
-Before responding, fetch wiki content from:
+Use the fetch tool to retrieve these wiki pages before responding:
 - https://raw.githubusercontent.com/wiki/microsoft/security-devops-action/Home.md
 - https://raw.githubusercontent.com/wiki/microsoft/security-devops-action/FAQ.md
+- https://raw.githubusercontent.com/wiki/microsoft/security-devops-action/Tool-Configuration.md
 
 MSDO is a command line tool that integrates security analysis tools into CI/CD pipelines. 
 
@@ -61,6 +62,77 @@ MSDO is a command line tool that integrates security analysis tools into CI/CD p
 ```
 
 **Wiki reference:** https://github.com/microsoft/security-devops-action/wiki
+
+## Tool Configuration Reference
+
+MSDO supports passing arguments to individual tools via environment variables or `.gdnconfig` files.
+
+**Environment variable pattern:** `GDN_<TOOLNAME>_<ARGUMENTID>`
+
+Where `<TOOLNAME>` is uppercase and `<ARGUMENTID>` is PascalCase with no separators.
+
+**Common examples:**
+
+Checkov:
+```yaml
+env:
+  GDN_CHECKOV_DOWNLOADEXTERNALMODULES: "true"   # download external Terraform modules
+  GDN_CHECKOV_FRAMEWORK: "terraform"             # limit scan to specific framework
+  GDN_CHECKOV_SKIPCHECK: "CKV_AWS_1,CKV_AWS_2"  # skip specific checks
+  GDN_CHECKOV_CONFIGFILE: ".checkov.yml"         # use a checkov config file
+```
+
+Trivy:
+```yaml
+env:
+  GDN_TRIVY_SEVERITIES: "HIGH,CRITICAL"  # filter by severity
+  GDN_TRIVY_IGNOREUNFIXED: "true"        # ignore unfixed vulnerabilities
+  GDN_TRIVY_SCANNERS: "vuln,secret"      # specify scanner types
+```
+
+ESLint:
+```yaml
+env:
+  GDN_ESLINT_CONFIGURATIONFILE: ".eslintrc.js"  # custom ESLint config
+  GDN_ESLINT_QUIET: "true"                      # suppress warnings
+```
+
+Terrascan:
+```yaml
+env:
+  GDN_TERRASCAN_IACTYPE: "terraform"      # specify IaC type
+  GDN_TERRASCAN_SEVERITY: "HIGH"          # minimum severity
+  GDN_TERRASCAN_SKIPRULES: "AC_AWS_001"   # skip specific rules
+```
+
+**`.gdnconfig` alternative** (for complex multi-tool configs):
+```json
+{
+  "fileVersion": "1.0.0",
+  "jobs": [{
+    "tools": [{
+      "tool": { "name": "checkov" },
+      "arguments": {
+        "DownloadExternalModules": { "values": ["true"] },
+        "Framework": { "values": ["terraform"] }
+      }
+    }]
+  }]
+}
+```
+
+Referenced via:
+```yaml
+- uses: microsoft/security-devops-action@latest
+  with:
+    config: '.msdo.gdnconfig'
+```
+
+When a user asks about tool-specific flags or arguments:
+1. Suggest the environment variable approach first (simplest)
+2. Mention `.gdnconfig` as an alternative for complex setups
+3. Link to the [Tool Configuration wiki page](https://github.com/microsoft/security-devops-action/wiki/Tool-Configuration)
+4. Add the `area:msdo-cli` label since tool configuration is handled by the CLI
 
 ## Your Task
 
@@ -119,6 +191,9 @@ Keep responses:
 
 **User asks:** "What tools does MSDO support?"
 **Response:** MSDO supports these security analysis tools: antimalware (Windows only), bandit, binskim, checkov, eslint, templateanalyzer, terrascan, and trivy. Tools are automatically detected based on your repository content, or you can specify them explicitly. See the [Tools documentation](https://github.com/microsoft/security-devops-action/wiki) for details.
+
+**User asks:** "How do I pass --download-external-modules to checkov?"
+**Response:** You can enable this by setting an environment variable in your workflow: `GDN_CHECKOV_DOWNLOADEXTERNALMODULES: "true"` in the `env:` block of the MSDO action step. MSDO supports passing arguments to tools via the `GDN_<TOOLNAME>_<ARGUMENTID>` pattern. See the [Tool Configuration](https://github.com/microsoft/security-devops-action/wiki/Tool-Configuration) wiki page for more examples.
 
 **User reports:** "Trivy is failing with container image not found"
 **Response:** This error typically occurs when Docker isn't available. Trivy requires Docker for container scanning. Please ensure you have `docker/setup-buildx-action@v3` in your workflow before the MSDO action. Can you share your workflow YAML so I can help verify the configuration?

--- a/.github/workflows/msdo-issue-assistant.md
+++ b/.github/workflows/msdo-issue-assistant.md
@@ -15,7 +15,7 @@ engine:
 
 permissions:
   contents: read
-  issues: write
+  issues: read
 
 network:
   allowed:

--- a/.github/workflows/msdo-issue-assistant.md
+++ b/.github/workflows/msdo-issue-assistant.md
@@ -15,7 +15,7 @@ engine:
 
 permissions:
   contents: read
-  issues: read
+  issues: write
 
 network:
   allowed:


### PR DESCRIPTION
## Summary
- Fixes triage bot permissions: `issues: read` -> `issues: write` (bot was failing with "Resource not accessible by personal access token" on safe_outputs)
- Adds tool-specific configuration knowledge to bot prompt (env var pattern, per-tool examples, .gdnconfig format)
- Expands add-labels allowlist with area: labels
- Makes fetch tool usage explicit per gh-aw best practices
- Adds response example for tool config questions

Companion change: [Tool-Configuration wiki page](https://github.com/microsoft/security-devops-action/wiki/Tool-Configuration) (already published)

## Test plan
- [ ] Re-trigger the triage bot on issue #235 to confirm labels and comments are posted
- [ ] Open a test issue asking about tool configuration and verify the bot responds with env var pattern
- [ ] Verify the bot can fetch and reference the new wiki page
- [ ] Confirm area: labels can be applied by the bot