### PR TITLE
fix(security): resolve ReDoS in image name validation regex

### DIFF
--- a/lib/v2/defender-helpers.js
+++ b/lib/v2/defender-helpers.js
@@ -120,7 +120,7 @@ function validateImageName(imageName) {
         throw new Error('Image name cannot be empty for image scan');
     }
     const trimmedImageName = imageName.trim();
-    const imageNameRegex = /^(?:(?:[a-zA-Z0-9._-]+(?:\.[a-zA-Z0-9._-]+)*(?::[0-9]+)?\/)?[a-zA-Z0-9._-]+(?:\/[a-zA-Z0-9._-]+)*)(?::[a-zA-Z0-9._-]+|@sha256:[a-fA-F0-9]{64})?$/;
+    const imageNameRegex = /^(?:(?:[a-zA-Z0-9_-]+(?:\.[a-zA-Z0-9_-]+)*(?::[0-9]+)?\/)?[a-zA-Z0-9._-]+(?:\/[a-zA-Z0-9._-]+)*)(?::[a-zA-Z0-9._-]+|@sha256:[a-fA-F0-9]{64})?$/;
     if (!imageNameRegex.test(trimmedImageName)) {
         throw new Error(`Invalid image name format: ${trimmedImageName}. Image name should follow container image naming conventions.`);
     }

--- a/src/v2/defender-helpers.ts
+++ b/src/v2/defender-helpers.ts
@@ -136,7 +136,7 @@ export function validateImageName(imageName: string): string {
 
     const trimmedImageName = imageName.trim();
 
-    const imageNameRegex = /^(?:(?:[a-zA-Z0-9._-]+(?:\.[a-zA-Z0-9._-]+)*(?::[0-9]+)?\/)?[a-zA-Z0-9._-]+(?:\/[a-zA-Z0-9._-]+)*)(?::[a-zA-Z0-9._-]+|@sha256:[a-fA-F0-9]{64})?$/;
+    const imageNameRegex = /^(?:(?:[a-zA-Z0-9_-]+(?:\.[a-zA-Z0-9_-]+)*(?::[0-9]+)?\/)?[a-zA-Z0-9._-]+(?:\/[a-zA-Z0-9._-]+)*)(?::[a-zA-Z0-9._-]+|@sha256:[a-fA-F0-9]{64})?$/;
 
     if (!imageNameRegex.test(trimmedImageName)) {
         throw new Error(`Invalid image name format: ${trimmedImageName}. Image name should follow container image naming conventions.`);


### PR DESCRIPTION
## Summary
- Fix exponential backtracking vulnerability in `validateImageName` regex (CodeQL alert #352)
- Remove `.` from hostname character classes so it only matches as a segment separator, eliminating ambiguous quantifier overlap

## Test plan
- [ ] Verify valid image names still pass: `registry.example.com:5000/org/image:tag`, `myimage:latest`, `org/image@sha256:abc...`
- [ ] Verify ReDoS input `-.-.-.-.-.-.-.-.-.-.` no longer causes hang