### PR TITLE
fix(toolkit): honor HTTPS_PROXY when installing the CLI; docs: close three documentation gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,22 @@ To upload results to the Security tab of your repo, run the `github/codeql-actio
     sarif_file: ${{ steps.msdo.outputs.sarifFile }}
 ```
 
+## Publish results from another tool
+
+To send SARIF produced by a tool this action does not run, set `existingFilename` to that file. The analyzers are skipped and the file is uploaded to the MSDO backend instead.
+
+```yaml
+- name: Run a third party scanner
+  run: my-scanner --sarif-output results.sarif
+
+- name: Publish existing SARIF
+  uses: microsoft/security-devops-action@latest
+  with:
+    existingFilename: results.sarif
+```
+
+Run this as its own step. When `existingFilename` is set no analyzers run, so it cannot be combined with a scanning step, and the `sarifFile` output is not set. To also surface the file in the Security tab, pass it to `github/codeql-action/upload-sarif` directly.
+
 ## Advanced
 
 To only run specific analyzers, use the `tools` command. This command is a comma-seperated list of tools to run. For example, to run only the `container-mapping` tool, configure this action as follows:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # microsoft/security-devops-action (Preview)
 
-Microsoft Security DevOps (MSDO) is a command line application which integrates static analysis tools into the development cycle. MSDO installs, configures and runs static analysis tools (including, but not limited to, SDL/security and compliance tools). MSDO is data-driven with portable configurations that enable deterministic execution across multiple environments. For tools that output results in or MSDO can convert their results to SARIF, MSDO imports into a normalized file database for seamlessly reporting and responding to results across tools, such as forcing build breaks.
+Microsoft Security DevOps (MSDO) is a command line application which integrates static analysis tools into the development cycle. MSDO installs, configures and runs static analysis tools (including, but not limited to, SDL/security and compliance tools). MSDO is data-driven with portable configurations that enable deterministic execution across multiple environments. For tools that output results in SARIF, or whose results MSDO can convert to SARIF, MSDO imports them into a normalized file database for seamlessly reporting and responding to results across tools, such as forcing build breaks.
 
 Run locally. Run remotely.
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ If `tools` is not set, the MSDO CLI decides which analyzers to run by inspecting
 
 Use `categories` or `languages` to narrow a run while still letting the CLI select the tools.
 
-`container-mapping` behaves differently from the other entries in the table below. It is implemented by this action's `pre` and `post` steps rather than by the CLI, so it is never passed to the CLI as an analyzer, and its pre and post steps run on every use of this action regardless of `tools`. Listing it as the only value of `tools` is therefore how you skip the analyzer run and keep container mapping on its own.
+`container-mapping` behaves differently from the other entries in the table below. It is implemented by this action's `pre` and `post` steps rather than by the CLI, and those steps run on every use of this action regardless of `tools`. Listing it as the only value of `tools` is therefore how you skip the analyzer run and keep container mapping on its own.
 
 # Tools
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ To only run specific analyzers, use the `tools` command. This command is a comma
     tools: container-mapping
 ```
 
+## How tools are selected
+
+If `tools` is not set, the MSDO CLI decides which analyzers to run by inspecting the repository contents. That selection logic lives in the CLI, not in this action. If `tools` is set, only the listed analyzers run and no content based selection takes place.
+
+Use `categories` or `languages` to narrow a run while still letting the CLI select the tools.
+
+`container-mapping` behaves differently from the other entries in the table below. It is implemented by this action's `pre` and `post` steps rather than by the CLI, so it is never passed to the CLI as an analyzer, and its pre and post steps run on every use of this action regardless of `tools`. Listing it as the only value of `tools` is therefore how you skip the analyzer run and keep container mapping on its own.
+
 # Tools
 
 | Name | Language | License |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # microsoft/security-devops-action (Preview)
 
-Microsoft Security DevOps (MSDO) is a command line application which integrates static analysis tools into the development cycle. MSDO installs, configures and runs the latest versions of static analysis tools (including, but not limited to, SDL/security and compliance tools). MSDO is data-driven with portable configurations that enable deterministic execution across multiple environments. For tools that output results in or MSDO can convert their results to SARIF, MSDO imports into a normalized file database for seamlessly reporting and responding to results across tools, such as forcing build breaks.
+Microsoft Security DevOps (MSDO) is a command line application which integrates static analysis tools into the development cycle. MSDO installs, configures and runs static analysis tools (including, but not limited to, SDL/security and compliance tools). MSDO is data-driven with portable configurations that enable deterministic execution across multiple environments. For tools that output results in or MSDO can convert their results to SARIF, MSDO imports into a normalized file database for seamlessly reporting and responding to results across tools, such as forcing build breaks.
 
 Run locally. Run remotely.
 
@@ -10,7 +10,7 @@ This action runs the [Microsoft Security DevOps CLI](https://aka.ms/msdo-nuget) 
 
 * Installs the Microsoft Security DevOps CLI
 * Installs the latest Microsoft security policy
-* Installs the latest Microsoft and 3rd party security tools
+* Installs the Microsoft and 3rd party security tools bundled with that CLI release
 * Automatic or user-provided configuration of security tools
 * Execution of a full suite of security tools
 * Normalized processing of results into the SARIF format
@@ -72,6 +72,8 @@ To only run specific analyzers, use the `tools` command. This command is a comma
 | [Terrascan](https://github.com/accurics/terrascan) | Infrastructure-as-code (IaC), Terraform (HCL2), Kubernetes (JSON/YAML), Helm v3, Kustomize, Dockerfiles, Cloudformation | [Apache License 2.0](https://github.com/accurics/terrascan/blob/master/LICENSE) |
 | [Trivy](https://github.com/aquasecurity/trivy) | container images, file systems, and git repositories | [Apache License 2.0](https://github.com/aquasecurity/trivy/blob/main/LICENSE) |
 | [container-mapping](https://learn.microsoft.com/en-us/azure/defender-for-cloud/container-image-mapping) | container images and registries (only available for DevOps security enabled CSPM plans) | [MIT License](https://github.com/microsoft/security-devops-action/blob/main/LICENSE) |
+
+Tool versions are pinned to the installed Microsoft Security DevOps CLI release rather than resolved independently, so a version published upstream is only picked up once a CLI release that bundles it is available.
 
 # More Information
 

--- a/node_modules/@microsoft/security-devops-actions-toolkit/msdo-nuget-client.js
+++ b/node_modules/@microsoft/security-devops-actions-toolkit/msdo-nuget-client.js
@@ -360,7 +360,14 @@ function resolveRequestOptions(accessToken) {
     return options;
 }
 function resolveProxyAgent(url) {
-    let proxyUrl = proxy.getProxyUrl(new URL(url));
+    let proxyUrl;
+    try {
+        proxyUrl = proxy.getProxyUrl(new URL(url));
+    }
+    catch (error) {
+        core.debug(`Failed to resolve the proxy configuration: ${error.message}`);
+        return undefined;
+    }
     if (proxyUrl === undefined || common.isNullOrWhiteSpace(proxyUrl.hostname)) {
         return undefined;
     }

--- a/node_modules/@microsoft/security-devops-actions-toolkit/msdo-nuget-client.js
+++ b/node_modules/@microsoft/security-devops-actions-toolkit/msdo-nuget-client.js
@@ -38,7 +38,9 @@ const fs = __importStar(require("fs"));
 const path = __importStar(require("path"));
 const process = __importStar(require("process"));
 const core = __importStar(require("@actions/core"));
+const proxy = __importStar(require("@actions/http-client/lib/proxy"));
 const AdmZip = require("adm-zip");
+const tunnel = require("tunnel");
 const common = __importStar(require("./msdo-common"));
 const _defaultFileDownloadRetries = 2;
 const _defaultFileDownloadRetryDelayMs = 1000;
@@ -357,10 +359,28 @@ function resolveRequestOptions(accessToken) {
     }
     return options;
 }
+function resolveProxyAgent(url) {
+    let proxyUrl = proxy.getProxyUrl(new URL(url));
+    if (proxyUrl === undefined || common.isNullOrWhiteSpace(proxyUrl.hostname)) {
+        return undefined;
+    }
+    let agentOptions = {
+        proxy: {
+            host: proxyUrl.hostname,
+            port: proxyUrl.port
+        }
+    };
+    if (!common.isNullOrWhiteSpace(proxyUrl.username) || !common.isNullOrWhiteSpace(proxyUrl.password)) {
+        agentOptions.proxy['proxyAuth'] = `${proxyUrl.username}:${proxyUrl.password}`;
+    }
+    core.debug(`Using proxy: ${proxyUrl.protocol}//${proxyUrl.hostname}:${proxyUrl.port}`);
+    return proxyUrl.protocol === 'https:' ? tunnel.httpsOverHttps(agentOptions) : tunnel.httpsOverHttp(agentOptions);
+}
 function requestJson(url, options) {
     return __awaiter(this, void 0, void 0, function* () {
         return new Promise((resolve, reject) => {
             core.debug(`${options['method'].toUpperCase()} ${url}`);
+            options['agent'] = resolveProxyAgent(url);
             const req = https.request(url, options, (res) => __awaiter(this, void 0, void 0, function* () {
                 try {
                     const decompressResponse = yield Promise.resolve().then(() => __importStar(require('decompress-response')));
@@ -422,6 +442,7 @@ function downloadFile(url, options, destinationPath, retries = _defaultFileDownl
 function _downloadFile(url, options, destinationPath) {
     return __awaiter(this, void 0, void 0, function* () {
         return new Promise((resolve, reject) => __awaiter(this, void 0, void 0, function* () {
+            options['agent'] = resolveProxyAgent(url);
             const req = https.request(url, options, (res) => __awaiter(this, void 0, void 0, function* () {
                 if (res.statusCode === 303) {
                     let redirectUrl = res.headers['location'];


### PR DESCRIPTION
Addresses four open issues: one behavioral fix and three documentation gaps.

## `fix(toolkit)`: honor `HTTPS_PROXY` and `NO_PROXY` when downloading the MSDO CLI

Fixes #61.

`resolveRequestOptions` in `msdo-nuget-client.js` returned request options with no `agent`, and both `https.request` call sites — the NuGet service-index/metadata lookup and the `.nupkg` download — inherited that. Node's `https` does not read proxy environment variables on its own, so on a runner behind an egress proxy the install reached out directly and hung or failed, regardless of `HTTPS_PROXY` being set.

This adds `resolveProxyAgent(url)`, which reuses `@actions/http-client`'s `getProxyUrl` for env-var and `NO_PROXY` resolution and builds a `tunnel` agent, then assigns it at both call sites. Behavior is unchanged when no proxy is configured — `getProxyUrl` returns `undefined` and `options['agent']` stays unset, so requests take exactly the path they take today. A proxy environment variable that is not a valid URL (`HTTPS_PROXY=10.0.0.5:3128`, no scheme) also falls back to a direct connection rather than failing the install.

Both `@actions/http-client` and `tunnel` are already present and committed under `node_modules/`, so the new `require`s resolve without a dependency change.

**Caveat.** `msdo-nuget-client.js` lives under `node_modules/` but is committed — only five toolkit files are tracked — so this is effective at runtime. It will be lost on the next bump of `@microsoft/security-devops-actions-toolkit`. The same fix needs to land upstream in [`microsoft/security-devops-actions-toolkit`](https://github.com/microsoft/security-devops-actions-toolkit), where `@actions/http-client` and `tunnel` should also be declared dependencies rather than relying on the consumer's tree. The upstream fix would also cover the equivalent Azure DevOps task reports.

## `docs`: bundled tool versions track the MSDO CLI release

Fixes #267.

The README claimed MSDO "installs the latest versions of static analysis tools". It does not — third-party tool binaries ship as redist packages pinned to a CLI release, so a version published upstream is only picked up once a CLI release bundling it exists. The claim set an expectation the action cannot meet. Reworded, with an explicit note under the tools table.

## `docs`: document `existingFilename`

Fixes #36.

`existingFilename` has been declared in `action.yml` since the input was added and maps to `upload --file`, but appears in zero markdown files, so the "can I publish SARIF from another tool?" question had no discoverable answer. Documents it, including that it short-circuits the analyzer run and does not set the `sarifFile` output.

## `docs`: explain tool selection and the `container-mapping` exception

Fixes #135.

Adds a "How tools are selected" section covering the `tools`-set vs `tools`-unset paths and the `container-mapping` asymmetry: it is implemented by this action's `pre`/`post` steps rather than by the CLI, is filtered out of `--tool` in `src/v1/msdo.ts`, and its pre/post steps run on every use of the action regardless of `tools`. The content-based selection logic itself lives in the closed-source CLI, and the section says so rather than guessing at per-tool trigger conditions.

## Validation

`npm run buildAndTest` could not be run in the authoring environment — devDependencies are not installed and the npm registry fails the TLS handshake there. No `src/v1/*.ts` file is touched, so the committed `lib/` does not need regenerating; CI covers the build.

For the JS change:

- `node --check` on `msdo-nuget-client.js` — passes.
- Module loads and both new `require`s resolve from the toolkit directory.
- `resolveProxyAgent` exercised directly against the real vendored `tunnel` and `@actions/http-client/lib/proxy`, 11/11 cases: no proxy env (returns `undefined`, direct); `HTTPS_PROXY` over http; lowercase `https_proxy`; `HTTPS_PROXY` over https (`httpsOverHttps`); proxy with credentials (`proxyAuth` populated); `NO_PROXY` matching the target host (bypass); `NO_PROXY` not matching (proxied); `HTTP_PROXY` alone correctly ignored for an https target; malformed `HTTPS_PROXY` (direct); scheme-less `HTTPS_PROXY` (direct); proxy URL without an explicit port.
